### PR TITLE
Update snapcraft.yaml to include libgl dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,6 +74,7 @@ parts:
       - libswresample-dev
       - libavfilter-dev
     stage-packages:
+      - libgl1-mesa-glx
       - lua-filesystem
       - lua-lpeg
       - freepats


### PR DESCRIPTION
Tracking the missing library led to the package now included in `snapcraft.yaml`.