### PR TITLE
Remove $LD_LIBRARY_PATH variable from LD_LIBRARY_PATH definition.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
   corsixth:
     command: desktop-launch $SNAP/bin/corsix-th $SNAP/share/corsix-th/CorsixTH.lua
     environment:
-      LD_LIBRARY_PATH: '$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lua/5.3/:$LD_LIBRARY_PATH'
+      LD_LIBRARY_PATH: '$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lua/5.3/'
       LUA_CPATH: '$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lua/5.3/?.so;;'
       LUA_PATH: '$SNAP/share/corsix-th/Lua/?.lua;;'
       TIMIDITY_CFG: $SNAP/timidity.cfg


### PR DESCRIPTION
$LD_LIBRARY_PATH starts as null and thus leaves a trailing colon.
An extra colon will be added in a later invocation of snapcraft_runner,
and will result in the current working directory being searched by ld.

(See my comments at https://forum.snapcraft.io/t/ann-snapcraft-4-4-4-library-injection-vulnerability-on-built-snaps/21465/5?u=james-carroll )