### PR TITLE
Add GUI smoke test workflow

### DIFF
--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -1,4 +1,4 @@
-name: Build snap
+name: Build and smoke test snap
 
 on:
   push:
@@ -35,3 +35,67 @@ jobs:
           name: corsixth-snap
           path: ${{ steps.build.outputs.snap }}
           retention-days: 7
+
+  smoke-test:
+    name: Launch snap and capture screenshots
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: corsixth-snap
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Install ghvmctl
+        run: |
+          sudo snap install ghvmctl
+          sudo snap connect ghvmctl:lxd lxd:lxd
+
+      - name: Prepare VM
+        run: ghvmctl prepare
+
+      - name: Install local snap in VM
+        run: |
+          set -eux
+          SNAP_FILE=$(find . -maxdepth 1 -name '*.snap' | head -n 1)
+          VM_NAME=$(ghvmctl exec -- hostname | tr -d '\n')
+          lxc file push "$SNAP_FILE" "local:${VM_NAME}/home/ubuntu/$(basename "$SNAP_FILE")"
+          ghvmctl exec -- sudo snap install --dangerous "/home/ubuntu/$(basename "$SNAP_FILE")"
+
+      - name: Launch CorsixTH
+        run: |
+          ghvmctl snap-run corsixth.corsixth
+          sleep 30
+
+      - name: Capture screenshots
+        if: always()
+        run: |
+          ghvmctl screenshot-full
+          ghvmctl screenshot-window
+          ls -lh "$HOME/ghvmctl-screenshots/" || true
+
+      - name: Show app logs
+        if: always()
+        run: ghvmctl exec -- cat /home/ubuntu/corsixth.corsixth.log 2>/dev/null || true
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: corsixth-screenshots
+          path: ~/ghvmctl-screenshots/
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ Pushing a branch triggers `.github/workflows/snap-build.yml`, which:
 
 - builds the snap
 - runs review checks
+- installs the built snap in a temporary VM
+- launches CorsixTH and captures screenshots
 - uploads the generated snap as a workflow artifact
+
+The launch smoke test only verifies that the GUI starts; it does not provide
+Theme Hospital game data.
 
 ## Notes
 
-- CorsixTH requires Theme Hospital game data from an original copy or the demo; the snap does not bundle it.
+- CorsixTH requires Theme Hospital game data from an original copy or the demo for actual gameplay; the snap does not bundle it.
 - The main packaging definition lives in `snap/snapcraft.yaml`.
-- A smoke test workflow is intentionally omitted here because the app cannot launch usefully in CI without external game data.

--- a/snap/local/bin/launch
+++ b/snap/local/bin/launch
@@ -2,4 +2,14 @@
 
 set -eu
 
+lua_triplet_dir="$(find "$SNAP/usr/lib" -mindepth 1 -maxdepth 1 -type d -name '*-linux-gnu' | head -n 1)"
+
+if [ -n "${lua_triplet_dir}" ]; then
+  export LUA_CPATH="${lua_triplet_dir}/lua/5.3/?.so;$SNAP/usr/lib/lua/5.3/?.so;;"
+else
+  export LUA_CPATH="$SNAP/usr/lib/lua/5.3/?.so;;"
+fi
+
+export LUA_PATH="$SNAP/usr/local/share/corsix-th/Lua/?.lua;$SNAP/usr/share/lua/5.3/?.lua;;"
+
 exec "$SNAP/usr/local/bin/corsix-th" --interpreter="$SNAP/usr/local/share/corsix-th/CorsixTH.lua" "$@"

--- a/snap/local/bin/launch
+++ b/snap/local/bin/launch
@@ -2,4 +2,4 @@
 
 set -eu
 
-exec "$SNAP/usr/bin/corsix-th" --interpreter="$SNAP/usr/share/corsix-th/CorsixTH.lua" "$@"
+exec "$SNAP/usr/local/bin/corsix-th" --interpreter="$SNAP/usr/local/share/corsix-th/CorsixTH.lua" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,8 +23,6 @@ apps:
     extensions: [gnome]
     command: bin/launch
     environment:
-      LUA_CPATH: '$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lua/5.3/?.so;;'
-      LUA_PATH: '$SNAP/usr/local/share/corsix-th/Lua/?.lua;;'
       TIMIDITY_CFG: $SNAP/timidity.cfg
     plugs:
       - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ apps:
     command: bin/launch
     environment:
       LUA_CPATH: '$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lua/5.3/?.so;;'
-      LUA_PATH: '$SNAP/usr/share/corsix-th/Lua/?.lua;;'
+      LUA_PATH: '$SNAP/usr/local/share/corsix-th/Lua/?.lua;;'
       TIMIDITY_CFG: $SNAP/timidity.cfg
     plugs:
       - network


### PR DESCRIPTION
## Summary
- extend the snap workflow to install the built snap in a VM, launch CorsixTH, and capture screenshots
- fix the snap launcher to use the actual `/usr/local` install layout
- set the Lua search paths in the launcher so bundled modules load correctly at runtime
- update the README to describe the smoke-test flow and its limits

## Testing
- fork Actions smoke-test run 24694084850 passed
